### PR TITLE
Fix the system message parameter handling issue in the OpenAIProvider class

### DIFF
--- a/index/llm/llm.py
+++ b/index/llm/llm.py
@@ -154,6 +154,7 @@ class LLMModel(Enum):
     GPT35 = "gpt-3.5-turbo"
     CLAUDE3_OPUS = "claude-3-opus-20240229"
     CLAUDE3_SONNET = "claude-3-sonnet-20240229"
+    QWEN25_VL_72B = "qwen2.5-vl-72b-instruct"
     # Add more models as needed
 
 class LLMResponse(BaseModel):

--- a/index/llm/providers/openai.py
+++ b/index/llm/providers/openai.py
@@ -7,8 +7,16 @@ from ..llm import BaseLLMProvider, LLMResponse, Message
 
 class OpenAIProvider(BaseLLMProvider):
     def __init__(self, model: str, system_message: Optional[str] = None):
-        super().__init__(model=model, system_message=system_message)
+        super().__init__(model=model)
+        self.system_message = system_message
         self.client = AsyncOpenAI()
+        
+    def _prepare_messages(self, messages: List[Message]) -> List[Message]:
+        """Prepare message list, add system message to the beginning if available"""
+        if self.system_message and not any(msg.role == "system" for msg in messages):
+            system_message = Message(role="system", content=self.system_message)
+            return [system_message] + messages
+        return messages
 
     async def call(
         self,


### PR DESCRIPTION
1. Modify the OpenAIProvider.init method to pass only the model parameter to the base class.
2. Save the system_message as an instance attribute.
3. Add a _prepare_messages method for handling the system message.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `OpenAIProvider` to handle system messages by storing them as attributes and prepending them to messages if absent.
> 
>   - **Initialization**:
>     - Modify `OpenAIProvider.__init__` to pass only `model` to the base class.
>     - Store `system_message` as an instance attribute.
>   - **Message Handling**:
>     - Add `_prepare_messages` method to prepend `system_message` to messages if not present.
>   - **Behavior**:
>     - Ensure system message is included in `call()` method by using `_prepare_messages`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Findex&utm_source=github&utm_medium=referral)<sup> for ed05ee05dd53ed5348ce4cada6325cc188a0e89a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->